### PR TITLE
WoW support, Region support, Full data on return

### DIFF
--- a/src/Entity/BattleNetUser.php
+++ b/src/Entity/BattleNetUser.php
@@ -8,42 +8,42 @@ class BattleNetUser implements ResourceOwnerInterface
 {
 
     /**
-    * @var APIdata[]
+    * @var data[]
     * For WoW or SC2 API data
     */
 
-    public $APIdata = array();
+    public $data = array();
 
     public function __construct(array $attributes, $region)
     {
         // Detect if === SC2
         if (isset($attributes[0]['portrait'])){
 
-            $this->APIdata = $attributes;
+            $this->data = $attributes;
 
-            for ($i = 0; $i < count($this->APIdata); $i++) {
-                $this->APIdata[$i]['profile_url'] = "http://{$region}.battle.net/APIdata/en{$this->APIdata[$i]['profilePath']}";
+            for ($i = 0; $i < count($this->data); $i++) {
+                $this->data[$i]['profile_url'] = "http://{$region}.battle.net/data/en{$this->data[$i]['profilePath']}";
 
                 // Portrait URL links to a sheet of portraits, so we construct the proper one.
-                if (isset($this->APIdata[$i]['portrait'])) {
-                    $this->APIdata[$i]['portrait_url'] = substr($this->APIdata[$i]['portrait']->url, 0, strpos($this->APIdata[$i]['portrait']->url, '-'))
-                        . '-' . $this->APIdata[$i]['portrait']->offset . ".jpg";
+                if (isset($this->data[$i]['portrait'])) {
+                    $this->data[$i]['portrait_url'] = substr($this->data[$i]['portrait']->url, 0, strpos($this->data[$i]['portrait']->url, '-'))
+                        . '-' . $this->data[$i]['portrait']->offset . ".jpg";
                 }
             }
 
         }
         else{
-            $this->APIdata = $attributes;
+            $this->data = $attributes;
         }
     }
 
     public function toArray()
     {
-        return $this->APIdata;
+        return [$this->data];
     }
 
     public function getId()
     {
-        return $this->APIdata['id'];
+        return $this->data['id'];
     }
 }

--- a/src/Entity/BattleNetUser.php
+++ b/src/Entity/BattleNetUser.php
@@ -12,7 +12,7 @@ class BattleNetUser implements ResourceOwnerInterface
     * For WoW or SC2 API data
     */
 
-    public $data = array();
+    public $data;
 
     public function __construct(array $attributes, $region)
     {
@@ -39,11 +39,11 @@ class BattleNetUser implements ResourceOwnerInterface
 
     public function toArray()
     {
-        return [$this->data];
+        return $this->data;
     }
 
     public function getId()
     {
-        return $this->data['id'];
+        return $this->data[0]['id'];
     }
 }

--- a/src/Provider/BattleNet.php
+++ b/src/Provider/BattleNet.php
@@ -19,7 +19,7 @@ class BattleNet extends AbstractProvider
         "game" => "sc2"
     );
 
-    protected $_RODurl;
+    protected $_RODurl = "https://us.api.battle.net/sc2/profile/user?access_token=";
 
     public function settings(array $params)
     {


### PR DESCRIPTION
I was looking or a OAuth client for PHP + BNet, however I found WoW support was needed, so I added/updated a few items:
- Added region support.
- Added wow support.
- Changed return to get full use of returned data.
- Test updated.
- Readme updated.

-- Laravel untested with changes.
> I was not sure on testing with Laravel atm.

I changed the way the return happened, as there can be multiple 'characters' for example with WoW, the changes are to return the full data from the API request, returning only the first [0] I found gave me a Level 1 character.  The down side is the returns are no longer `$user->id;` and instead would be (using the test for example) `$user->data[0]['id'];`

Hope these changes are not too drastic, my primary goal was adding in WoW support :)