### PR TITLE
$data in checkResponse is an array

### DIFF
--- a/src/Provider/BattleNet.php
+++ b/src/Provider/BattleNet.php
@@ -85,8 +85,8 @@ abstract class BattleNet extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if ($response->getStatusCode() != 200) {
-            $data = json_decode($data, true);
-            throw new IdentityProviderException($data['message'], $response->getStatusCode(), $data);
+            $data = (is_array($data)) ? $data : json_decode($data, true);
+            throw new IdentityProviderException($data['error_description'], $response->getStatusCode(), $data);
         }
     }
 }


### PR DESCRIPTION
Fixed a bug with `checkResponse()` where it tried to use `json_decode` on `$data`, but in the case of error, `$data` was an array and not a string. Here's what `$data` contained:

```
array:2 [
  "error" => "invalid_request"
  "error_description" => "Internal server error"
]
```
